### PR TITLE
Merge develop/rename-to-docubleach

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-![MS Office Macro Bleach](docs/images/bleach.jpg)
+![DocuBleach](docs/images/bleach.jpg)
 
 
-# MacroBleach
+# DocuBleach
 
 A command-line tool designed to detect and purge any and all macros and dynamic content from commonly used office document formats (including MS Office Files, PDFs, etc.).
 
@@ -54,6 +54,6 @@ It should support all the common Office Open XML formats, 'legacy' MS binary fil
 
 This package has not yet been published. It can be used, however, by cloning the repo, opening the command prompt in it, and running the following command:
 
-```poetry run bleach <PATH_TO_FILE>```
+```poetry run docubleach <PATH_TO_FILE>```
 
 The optional '-c' flag may be appended to the command to enable notification if any macros are detected.

--- a/docubleach/bleach.py
+++ b/docubleach/bleach.py
@@ -1,4 +1,4 @@
-"""This module removes any and all macros/dynamic content from MS Office files.
+"""This module is designed to purge any and all macros and dynamic content from commonly used office formats.
 
 VBA and OLE content in MS Office files can, and have sometimes been made to, act as vehicles for malware delivery.
 
@@ -7,10 +7,6 @@ Microsoft has previously attempted to protect users from macros by disabling the
 However, anybody is able to enable macros in an MS Office file before sending them on to a potential victim.
 
 This module enables users to simply and safely remove any and all macros/dynamic content from MS Office files.
-
-It converts the given file into a '.zip' archive, unzips it, and deletes the files containing macro data.
-
-It then re-zips the unzipped archive and reverts it to its original file format.
 
 It is part of a suite of programs developed by the AntiMalware Alliance.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "ms-office-macro-bleach"
+name = "docubleach"
 version = "0.1.0"
 description = "Tool to purge and remove all macro and dynamic content from an MS Office file"
 authors = ["Patterbear"]
@@ -12,7 +12,7 @@ olefile = "^0.47"
 
 
 [tool.poetry.scripts]
-bleach = "ms_office_macro_bleach.bleach:main"
+docubleach = "docubleach.bleach:main"
 
 
 [build-system]

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -19,7 +19,7 @@ from subprocess import check_output
 from os import remove, rename
 from shutil import copyfile
 
-program_dir = "../ms_office_macro_bleach/"
+program_dir = "../docubleach/"
 
 
 def test_valid_file_with_macros():

--- a/tests/test_ooxml_files.py
+++ b/tests/test_ooxml_files.py
@@ -13,7 +13,7 @@ from os import remove, rename
 from shutil import copyfile
 
 
-program_dir = "../ms_office_macro_bleach/"
+program_dir = "../docubleach/"
 
 
 def test_word_document():


### PR DESCRIPTION
I believe I have made all references to the program refer to docubleach.

However I'm unable to alter name of the repository itself, so when installed the folder is still called its original name however I'm sure you can edit this easily.